### PR TITLE
Fix parsing of subtreeRef elements within a subtree

### DIFF
--- a/lib/model/data_criteria.rb
+++ b/lib/model/data_criteria.rb
@@ -81,7 +81,12 @@ module SimpleXml
       elsif element.name == Precondition::FUNCTIONAL_OP
         criteria = doc.data_criteria(Precondition.new(element, doc).reference.id)
       else
-        criteria = doc.criteria_map[element.at_xpath('@id').value].dup
+        criteria = doc.criteria_map[element.at_xpath('@id').value]
+        if !criteria && element.name == Precondition::SUB_TREE
+          criteria = doc.sub_tree_map[Utilities.attr_val(element, '@id')].convert_to_data_criteria
+          doc.register_source_data_criteria(criteria)
+        end
+        criteria = criteria.dup
         return criteria if criteria.id == HQMF::Document::MEASURE_PERIOD_ID
 
         # if we have attributes then we want to update the ID sice we have changed the DC
@@ -141,7 +146,11 @@ module SimpleXml
     end
     
     def dup
-      DataCriteria.new(@entry, @id)
+      if @entry
+        DataCriteria.new(@entry, @id)
+      else
+        Marshal.load(Marshal.dump(self))
+      end
     end
 
     def add_temporal(temporal)

--- a/lib/model/document.rb
+++ b/lib/model/document.rb
@@ -121,6 +121,14 @@ module SimpleXml
       observ
     end
 
+    def register_source_data_criteria(criteria)
+      sdc = criteria.dup
+      sdc.subset_operators = nil if sdc.subset_operators
+      sdc.remove_instance_variable('@temporal_references') if sdc.temporal_references
+      @source_data_criteria << sdc
+      @criteria_map[criteria.hqmf_id] = criteria
+    end
+
     private
     
     def find(collection, attribute, value)

--- a/lib/model/sub_tree.rb
+++ b/lib/model/sub_tree.rb
@@ -27,20 +27,21 @@ module SimpleXml
       @precondition = ParsedPrecondition.new(HQMF::Counter.instance.next, [@precondition], nil, HQMF::Precondition::ALL_TRUE, false) if @precondition.reference
 
       # create the grouping data criteria for the variable
-      criteria = DataCriteria.convert_precondition_to_criteria(@precondition, @doc, 'variable')
+      criteria = convert_to_data_criteria('variable')
       criteria.instance_variable_set('@variable', true)
       criteria.instance_variable_set('@description', @entry.attributes['displayName'].value || attr_val('@displayName'))
       criteria.derivation_operator = (@precondition.conjunction_code == HQMF::Precondition::ALL_TRUE) ? HQMF::DataCriteria::INTERSECT : HQMF::DataCriteria::UNION if criteria.children_criteria
 
       # put variable in source data criteria
-      sdc = Marshal.load(Marshal.dump(criteria))
-      sdc.subset_operators = nil if sdc.subset_operators
-      sdc.remove_instance_variable('@temporal_references') if sdc.temporal_references
-      @doc.source_data_criteria << sdc
+      @doc.register_source_data_criteria(criteria)
 
       # update the reference to the variable data criteria
       @precondition.preconditions = []
       @precondition.reference = Reference.new(criteria.id)
+    end
+
+    def convert_to_data_criteria(operator='clause')
+      DataCriteria.convert_precondition_to_criteria(@precondition, @doc, operator)
     end
   end
 end


### PR DESCRIPTION
### Notes
- updated <code>data_criteria</code>.<code>get_criteria()</code> to create and register data criteria if non-existent when referencing a nested subtree
- updated <code>data_criteria</code>.<code>dup()</code> to clone via Marshal unless an entry is supplied
- moved source data criteria generation code into document helper method
- cleaned up subtree parsing code, added helper method for converting to data criteria
