### PR TITLE
Exhaustively parse population criteria to prevent duplication errors

### DIFF
--- a/lib/model/population_criteria.rb
+++ b/lib/model/population_criteria.rb
@@ -52,6 +52,11 @@ module SimpleXml
 
     end
 
+    def set_index(index)
+      @id = @type
+      @id += "_#{index}" if (index > 0)
+    end
+
     def translate_type(type)
       case type
       when IPP, 'initialPopulation'


### PR DESCRIPTION
### Notes
- fix measure grouping/population criteria parsing (noted for CMS155v3 R2 update) with misaligned STRAT populations
