### PR TITLE
Be more selective about what we add to source data criteria

### DIFF
--- a/lib/model/data_criteria.rb
+++ b/lib/model/data_criteria.rb
@@ -6,7 +6,8 @@ module SimpleXml
         :derivation_operator, :children_criteria, :subset_operators, :comments,
         :temporal_references, :specific_occurrence, :specific_occurrence_const
     attr_reader :hqmf_id, :title, :display_name, :description, :code_list_id, 
-        :definition, :status, :effective_time, :inline_code_list, :source_data_criteria
+        :definition, :status, :effective_time, :inline_code_list, :source_data_criteria,
+        :variable
   
     include SimpleXml::Utilities
     
@@ -84,7 +85,10 @@ module SimpleXml
         criteria = doc.criteria_map[element.at_xpath('@id').value]
         if !criteria && element.name == Precondition::SUB_TREE
           criteria = doc.sub_tree_map[Utilities.attr_val(element, '@id')].convert_to_data_criteria
-          doc.register_source_data_criteria(criteria)
+          # If this is a specific occurrence of a variable it won't appear in the elementLookUp, so include it in source data criteria here
+          if criteria.specific_occurrence && criteria.variable
+            doc.register_source_data_criteria(criteria)
+          end
         end
         criteria = criteria.dup
         return criteria if criteria.id == HQMF::Document::MEASURE_PERIOD_ID


### PR DESCRIPTION
source_data_criteria is (AFAIK) used for two purposes: providing a pick list of elements for patient record creation and listing Specific Occurrences. Before this fix, lots of extraneous elements were being added. In at least one instance this caused an issue because some Specific Occurrences would be added to the list multiple times, with slight variance. When calculating, more Specific Occurrences were accounted for than actually existed in the code.

Most Specific Occurrences wind up in the source_data_criteria when parsing the SimpleXML elementLookUp section, but not Specific Occurrences of variables, which were coming from this code. We still need this code for Specific Occurrences of variables, but now it's more specific to only add those specific elements.

This was tested by loading several SimpleXML measures and making sure that 1) the existing calculation problem was fixed 2) no calculation issues were introduced 3) the patient builder pick lists remained identical after the change.