### PR TITLE
Update HDS with latest field values, don't replace ORDINALITY

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/projectcypress/health-data-standards.git
-  revision: f02d2f7ec783f70f76e61fb06848ad706dcb702d
+  revision: 8c0b7c4b6e800e2da78cd74c88d218d01d3c2405
   branch: bonnie_master
   specs:
     health-data-standards (3.4.6)
@@ -55,12 +55,12 @@ GEM
     bson (2.3.0)
     builder (3.1.4)
     coderay (1.1.0)
-    connection_pool (2.1.0)
+    connection_pool (2.2.0)
     docile (1.1.3)
     erubis (2.7.0)
     hike (1.2.3)
     i18n (0.7.0)
-    json (1.8.2)
+    json (1.8.3)
     log4r (1.1.10)
     macaddr (1.7.1)
       systemu (~> 2.6.2)
@@ -79,17 +79,17 @@ GEM
       tzinfo (>= 0.3.37)
     mongoid-tree (1.0.4)
       mongoid (>= 3.0, <= 4.0)
-    moped (2.0.3)
+    moped (2.0.4)
       bson (~> 2.2)
       connection_pool (~> 2.0)
       optionable (~> 0.2.0)
-    multi_json (1.10.1)
+    multi_json (1.11.0)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
     optionable (0.2.0)
     origin (2.1.1)
     polyglot (0.3.5)
-    protected_attributes (1.0.8)
+    protected_attributes (1.0.9)
       activemodel (>= 4.0.1, < 5.0)
     pry (0.9.12.6)
       coderay (~> 1.0)
@@ -133,9 +133,9 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
-    systemu (2.6.4)
+    systemu (2.6.5)
     thor (0.19.1)
-    thread_safe (0.3.4)
+    thread_safe (0.3.5)
     tilt (1.4.1)
     treetop (1.4.15)
       polyglot
@@ -143,8 +143,8 @@ GEM
     turn (0.9.7)
       ansi
       minitest (~> 4)
-    tzinfo (0.3.42)
-    uuid (2.3.7)
+    tzinfo (0.3.44)
+    uuid (2.3.8)
       macaddr (~> 1.0)
 
 PLATFORMS

--- a/lib/model/data_criteria.rb
+++ b/lib/model/data_criteria.rb
@@ -5,12 +5,12 @@ module SimpleXml
     attr_accessor :id, :field_values, :value, :negation, :negation_code_list_id,
         :derivation_operator, :children_criteria, :subset_operators, :comments,
         :temporal_references, :specific_occurrence, :specific_occurrence_const
-    attr_reader :hqmf_id, :title, :display_name, :description, :code_list_id, 
+    attr_reader :hqmf_id, :title, :display_name, :description, :code_list_id,
         :definition, :status, :effective_time, :inline_code_list, :source_data_criteria,
         :variable
-  
+
     include SimpleXml::Utilities
-    
+
     # Create a new instance based on the supplied HQMF entry
     # @param [Nokogiri::XML::Element] entry the parsed HQMF entry
     def initialize(entry, id=nil)
@@ -24,7 +24,7 @@ module SimpleXml
 
       @source_data_criteria = @id
       @negation = false
-      
+
       # the following remain nil:
       # @display_name, @children_criteria, @derivation_operator, @value, @field_values,
       # @effective_time , @inline_code_list, @negation_code_list_id, @temporal_references, @subset_operators
@@ -72,7 +72,7 @@ module SimpleXml
     end
 
     def self.get_criteria(element, precondition_id, doc, subset=nil, operator=nil, update_id=false)
-      
+
       if element.name == Precondition::TEMPORAL_OP
         # we have a chain of temporal references
         criteria = convert_precondition_to_criteria(Precondition.new(element, doc), doc, operator)
@@ -103,7 +103,7 @@ module SimpleXml
         # handle attributes
         if (attributes)
           attributes.each do |attribute|
-            
+
             orig_key = attribute.at_xpath('@name').value
             key = DataCriteria.translate_field(orig_key)
             value = Attribute.translate_attribute(attribute, doc)
@@ -152,7 +152,7 @@ module SimpleXml
                                      end
       grouping
     end
-    
+
     def dup
       if @entry
         DataCriteria.new(@entry, @id)
@@ -169,7 +169,7 @@ module SimpleXml
     def push_down_temporal(temporal, doc)
       # push down through a grouping
       if @children_criteria
-        @children_criteria.each {|child_id| doc.data_criteria(child_id).push_down_temporal(temporal, doc)} 
+        @children_criteria.each {|child_id| doc.data_criteria(child_id).push_down_temporal(temporal, doc)}
       else
         # if this is not a grouping, just add the temporal reference
         add_temporal(temporal)
@@ -183,10 +183,9 @@ module SimpleXml
       @specific_occurrence_const = DataCriteria.format_so_const(@description)
       @id = id || format_id("#{instance} #{@title}#{specifics_counter}")
     end
-    
+
     def self.translate_field(name)
       name = name.tr(' ','_').upcase
-      name = 'ORDINAL' if name == 'ORDINALITY'
       raise "Unknown field name: #{name}" unless HQMF::DataCriteria::FIELDS[name] || name == 'RESULT' || name == 'NEGATION_RATIONALE'
       name
     end
@@ -202,9 +201,9 @@ module SimpleXml
       subs = subset_operators.collect {|o| o.to_model} if subset_operators
       @variable ||= false
 
-      HQMF::DataCriteria.new(@id, @title, @display_name, @description, @code_list_id, @children_criteria, 
-        @derivation_operator, @definition, @status, val, fv, @effective_time, @inline_code_list, 
-        @negation, @negation_code_list_id, trs, subs, @specific_occurrence, 
+      HQMF::DataCriteria.new(@id, @title, @display_name, @description, @code_list_id, @children_criteria,
+        @derivation_operator, @definition, @status, val, fv, @effective_time, @inline_code_list,
+        @negation, @negation_code_list_id, trs, subs, @specific_occurrence,
         @specific_occurrence_const, @source_data_criteria, comments, @variable)
     end
 
@@ -244,7 +243,7 @@ module SimpleXml
       if definition == 'medication_discharge'
         definition = 'medication'
         status = 'discharge'
-      end 
+      end
       status = nil if status && status.empty?
 
       {definition: definition, status: status}
@@ -261,7 +260,7 @@ module SimpleXml
     def fix_description_for_hqmf_match
       @description = "#{@definition.titleize}, #{@status.titleize}: #{@title}" if @status == 'ordered'
     end
- 
+
   end
-  
+
 end


### PR DESCRIPTION
### Notes ###
- updated HDS with latest field values
- do not replace 'ORDINALITY' with 'ORDINAL' anymore (there is still a failsafe in HDS, too)